### PR TITLE
feat: add SAML options and service type for OpenSearch

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -56,11 +56,23 @@ module "elasticsearch" {
   context = module.this.context
 }
 
-resource "aws_opensearch_domain_saml_options" "this" {
-  count = local.saml_options_enabled ? 1 : 0
+resource "aws_elasticsearch_domain_saml_options" "elasticsearch" {
+  count = local.saml_options_enabled && var.aws_service_type == "elasticsearch" ? 1 : 0
 
   domain_name = module.elasticsearch.domain_name
+  saml_options {
+    enabled = var.elasticsearch_saml_options.enabled
+    idp {
+      entity_id        = var.elasticsearch_saml_options.entity_id
+      metadata_content = var.elasticsearch_saml_options.metadata_content
+    }
+  }
+}
 
+resource "aws_opensearch_domain_saml_options" "opensearch" {
+  count = local.saml_options_enabled && var.aws_service_type == "opensearch" ? 1 : 0
+
+  domain_name = module.elasticsearch.domain_name
   saml_options {
     enabled = var.elasticsearch_saml_options.enabled
     idp {

--- a/src/main.tf
+++ b/src/main.tf
@@ -9,11 +9,10 @@ locals {
   elasticsearch_domain_endpoint = format(local.elasticsearch_endpoint_format, "elasticsearch_domain_endpoint")
   elasticsearch_kibana_endpoint = format(local.elasticsearch_endpoint_format, "elasticsearch_kibana_endpoint")
   elasticsearch_admin_password  = format(local.elasticsearch_endpoint_format, "password")
-}
 
-locals {
   create_password        = local.enabled && length(var.elasticsearch_password) == 0
-  elasticsearch_password = local.create_password ? join("", random_password.elasticsearch_password.*.result) : var.elasticsearch_password
+  elasticsearch_password = local.create_password ? one(random_password.elasticsearch_password[*].result) : var.elasticsearch_password
+  saml_options_enabled   = local.enabled && var.elasticsearch_saml_options.enabled
 }
 
 module "elasticsearch" {
@@ -25,6 +24,7 @@ module "elasticsearch" {
   subnet_ids                     = local.vpc_private_subnet_ids
   zone_awareness_enabled         = length(local.vpc_private_subnet_ids) > 1 ? true : false
   elasticsearch_version          = var.elasticsearch_version
+  aws_service_type               = var.aws_service_type
   instance_type                  = var.instance_type
   instance_count                 = length(local.vpc_private_subnet_ids)
   availability_zone_count        = length(local.vpc_private_subnet_ids)
@@ -54,6 +54,20 @@ module "elasticsearch" {
   }
 
   context = module.this.context
+}
+
+resource "aws_opensearch_domain_saml_options" "this" {
+  count = local.saml_options_enabled ? 1 : 0
+
+  domain_name = module.elasticsearch.domain_name
+
+  saml_options {
+    enabled = var.elasticsearch_saml_options.enabled
+    idp {
+      entity_id        = var.elasticsearch_saml_options.entity_id
+      metadata_content = var.elasticsearch_saml_options.metadata_content
+    }
+  }
 }
 
 resource "random_password" "elasticsearch_password" {
@@ -103,6 +117,8 @@ resource "aws_ssm_parameter" "elasticsearch_kibana_endpoint" {
 module "elasticsearch_log_cleanup" {
   source  = "cloudposse/lambda-elasticsearch-cleanup/aws"
   version = "0.16.1"
+
+  enabled = var.elasticsearch_log_cleanup_enabled
 
   es_endpoint          = module.elasticsearch.domain_endpoint
   es_domain_arn        = module.elasticsearch.domain_arn

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,49 +1,54 @@
 output "security_group_id" {
-  value       = module.elasticsearch.security_group_id
+  value       = local.enabled ? module.elasticsearch.security_group_id : null
   description = "Security Group ID to control access to the Elasticsearch domain"
 }
 
 output "domain_arn" {
-  value       = module.elasticsearch.domain_arn
+  value       = local.enabled ? module.elasticsearch.domain_arn : null
   description = "ARN of the Elasticsearch domain"
 }
 
 output "domain_id" {
-  value       = module.elasticsearch.domain_id
+  value       = local.enabled ? module.elasticsearch.domain_id : null
   description = "Unique identifier for the Elasticsearch domain"
 }
 
+output "domain_name" {
+  value       = local.enabled ? module.elasticsearch.domain_name : null
+  description = "Name of the Elasticsearch domain"
+}
+
 output "domain_endpoint" {
-  value       = module.elasticsearch.domain_endpoint
+  value       = local.enabled ? module.elasticsearch.domain_endpoint : null
   description = "Domain-specific endpoint used to submit index, search, and data upload requests"
 }
 
 output "kibana_endpoint" {
-  value       = module.elasticsearch.kibana_endpoint
+  value       = local.enabled ? module.elasticsearch.kibana_endpoint : null
   description = "Domain-specific endpoint for Kibana without https scheme"
 }
 
 output "domain_hostname" {
-  value       = module.elasticsearch.domain_hostname
+  value       = local.enabled ? module.elasticsearch.domain_hostname : null
   description = "Elasticsearch domain hostname to submit index, search, and data upload requests"
 }
 
 output "kibana_hostname" {
-  value       = module.elasticsearch.kibana_hostname
+  value       = local.enabled ? module.elasticsearch.kibana_hostname : null
   description = "Kibana hostname"
 }
 
 output "elasticsearch_user_iam_role_name" {
-  value       = module.elasticsearch.elasticsearch_user_iam_role_name
+  value       = local.enabled ? module.elasticsearch.elasticsearch_user_iam_role_name : null
   description = "The name of the IAM role to allow access to Elasticsearch cluster"
 }
 
 output "elasticsearch_user_iam_role_arn" {
-  value       = module.elasticsearch.elasticsearch_user_iam_role_arn
+  value       = local.enabled ? module.elasticsearch.elasticsearch_user_iam_role_arn : null
   description = "The ARN of the IAM role to allow access to Elasticsearch cluster"
 }
 
 output "master_password_ssm_key" {
-  value       = local.elasticsearch_admin_password
+  value       = local.enabled ? local.elasticsearch_admin_password : null
   description = "SSM key of Elasticsearch master password"
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -11,7 +11,7 @@ variable "instance_type" {
 variable "aws_service_type" {
   type        = string
   description = "The type of AWS service to deploy (`elasticsearch` or `opensearch`)."
-  # For backwards comptibility we default to elasticsearch
+  # For backwards compatibility we default to elasticsearch
   default = "elasticsearch"
 
   validation {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -8,9 +8,21 @@ variable "instance_type" {
   description = "The type of the instance"
 }
 
+variable "aws_service_type" {
+  type        = string
+  description = "The type of AWS service to deploy (`elasticsearch` or `opensearch`)."
+  # For backwards comptibility we default to elasticsearch
+  default = "elasticsearch"
+
+  validation {
+    condition     = contains(["elasticsearch", "opensearch"], var.aws_service_type)
+    error_message = "Value can only be one of `elasticsearch` or `opensearch`."
+  }
+}
+
 variable "elasticsearch_version" {
   type        = string
-  description = "Version of Elasticsearch to deploy (_e.g._ `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5`"
+  description = "Version of Elasticsearch or Opensearch to deploy (_e.g._ `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5`"
 }
 
 variable "encrypt_at_rest_enabled" {
@@ -98,6 +110,28 @@ variable "elasticsearch_password" {
     )
     error_message = "Password must be between 8 and 128 characters. If null is provided then a random password will be used."
   }
+}
+
+variable "elasticsearch_saml_options" {
+  type = object({
+    enabled          = optional(bool, false)
+    entity_id        = optional(string)
+    metadata_content = optional(string)
+  })
+  description = <<-EOT
+ Manages SAML authentication options for an AWS OpenSearch Domain
+
+ enabled: Whether to enable SAML authentication for the OpenSearch Domain
+ entity_id: The entity ID of the IdP
+ metadata_content: The metadata of the IdP
+ EOT
+  default     = {}
+}
+
+variable "elasticsearch_log_cleanup_enabled" {
+  type        = bool
+  description = "Whether to enable Elasticsearch log cleanup Lambda"
+  default     = true
 }
 
 variable "dns_delegated_environment_name" {


### PR DESCRIPTION
## what

- Added `aws_service_type` variable to support both Elasticsearch and OpenSearch deployments, with validation and default for backward compatibility.
- Introduced `elasticsearch_saml_options` variable and resource to manage SAML authentication for OpenSearch domains.
- Updated outputs to be conditional on `local.enabled`.
- Added `elasticsearch_log_cleanup_enabled` variable for log cleanup Lambda.
- Improved password generation logic for compatibility.

## why

- This introduces support for AWS OpenSearch domains alongside Elasticsearch, adds SAML authentication options, and improves configuration flexibility and output handling. The changes allow users to choose between deploying Elasticsearch or OpenSearch, enable SAML authentication for OpenSearch, and conditionally output resources based on module enablement. Log cleanup functionality is also made configurable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service-type selection for Elasticsearch or OpenSearch
  * SAML authentication configuration support for domains
  * Domain name output
  * Toggle to enable/disable log cleanup

* **Improvements**
  * Outputs now return null when the service is disabled for cleaner handling
  * Improved password handling and conditional resource creation flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->